### PR TITLE
Quick fix of UTF-8

### DIFF
--- a/lib/TOBYINK/Pod/HTML.pm
+++ b/lib/TOBYINK/Pod/HTML.pm
@@ -17,6 +17,7 @@ use XML::LibXML::QuerySelector ();
 	sub new
 	{
 		my $class = shift;
+		$Pod::Simple::HTML::Content_decl = q{<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" >};
 		my $self  = $class->SUPER::new(@_);
 		$self->perldoc_url_prefix("https://metacpan.org/pod/");
 		return $self;


### PR DESCRIPTION
By default Pod::Simple::HTML sets charset ISO-8859-1 for all generated HTML documents. This breaks support of all non-ASCII7 characters in result documents.